### PR TITLE
[🚀 Feat] 이력서 상세 페이지 DB 연결

### DIFF
--- a/server/controllers/commonController.js
+++ b/server/controllers/commonController.js
@@ -1,3 +1,4 @@
+const { default: mongoose } = require('mongoose');
 const { Resumes } = require('../models/resumes');
 
 // 메인
@@ -18,6 +19,25 @@ exports.templateList = async (req, res) => {
 // 이력서 작성
 exports.writeResume = async (req, res) => {
   res.send('이력서 작성');
+};
+// 이력서 상세
+exports.detailResume = async (req, res) => {
+  try {
+    const { resumeId } = req.params;
+    if (!mongoose.isValidObjectId(resumeId))
+      return res.status(400).send({ err: '유효한 ObjectId가 아닙니다.' });
+    const resume = await Resumes.findOne({ _id: resumeId }).collation({
+      locale: 'en',
+      strength: 2,
+    });
+    if (!resume) {
+      return res.status(404).send({ err: '해당 이력서가 없습니다.' });
+    }
+    return res.send({ detail: resume });
+  } catch (err) {
+    console.log(err);
+    return res.status(500).send({ err: err.message });
+  }
 };
 
 exports.mypage = async (req, res) => {

--- a/server/controllers/resumeController.js
+++ b/server/controllers/resumeController.js
@@ -13,17 +13,19 @@ const resumeController = {
     };
 
     try {
-      const newResume = new Resumes(data);
+      if (!name) return res.status(400).send({ err: 'name is required' });
+      const newResume = new Resumes(req.body);
       await newResume.save();
-      res.send('이력서 저장 성공');
+      return res.send({ '이력서 저장 성공': newResume });
     } catch (error) {
-      res.status(500).send('이력서 저장 실패:' + error.message);
+      return res.status(500).send({ '이력서 저장 실패': error.message });
     }
   },
 
   // 이력서 수정
   async editResume(req, res) {
-    // const {resumeId} = req.params;
+    const { resumeId } = req.params;
+
     res.send('이력서 수정');
   },
 

--- a/server/models/resumes.js
+++ b/server/models/resumes.js
@@ -13,7 +13,7 @@ const resumesSchema = new mongoose.Schema(
     structure: {
       title: String,
       template_type: String,
-      user_id: { type: Schema.Types.ObjectId, ref: 'User' },
+      // user_id: { type: Schema.Types.ObjectId, ref: 'User' },
       content: {
         work_experience: [
           {

--- a/server/routes/commonRouter.js
+++ b/server/routes/commonRouter.js
@@ -9,6 +9,8 @@ router.get('/intro', commonController.intro);
 router.get('/list', commonController.templateList);
 // 이력서 작성
 router.get('/resume', commonController.writeResume);
+// 이력서 상세
+router.get('/resume/:resumeId', commonController.detailResume);
 // 마이페이지
 router.get('/mypage', commonController.mypage);
 


### PR DESCRIPTION
[🚀 Feat] PR 이력서 상세 페이지 DB 연결


### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->
-  PR 이력서 상세 페이지 DB 연결
params 사용해서 id를 받고, 해당하는 MogoDB ObjectID DB 정보를 출력합니다. (/resume/:id)

- 이력서 저장 상태 코드 추가
name 필드를 입력하지 않으면 400에러코드 반환


### 작업 후 기대 동작(스크린샷) 
<!-- 작업 후 기대 동작(스크린샷) -->
- 이력서 상세 페이지 DB 연결
![image](https://github.com/Resumates/Resumates/assets/107483199/89a7af7e-cef3-46ea-ba44-6803db2a58c8)

- 이력서 저장 상태 코드 추가
- 현재 필드값 테스트 중으로 req.body로 DB 저장. 추후 data로 값 저장 할 예정
![image](https://github.com/Resumates/Resumates/assets/107483199/47ab469f-7c5c-4006-8614-1b317df6badc)


